### PR TITLE
Update dune-release-action to v0.4.0 with pr-preamble-message

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,10 +72,11 @@ jobs:
       - run: opam install dune-release -y
 
       - name: Run dune-release
-        uses: andreypopp/dune-release-action@6118dbc7ecba2b9acbd80bb8339dad5a579ef122
+        uses: davesnx/dune-release-action@v0.4.0
         with:
           packages: "mlx,ocamlmerlin-mlx"
           changelog: './CHANGES'
           github-token: ${{ secrets.GH_TOKEN }}
           to-opam-repository: true
           to-github-releases: true
+          pr-preamble-message: 'Released automatically by dune-release-action. Contact @davesnx or @andreypopp'


### PR DESCRIPTION
Updates `dune-release-action` to [v0.4.0](https://github.com/davesnx/dune-release-action/blob/main/CHANGES.md) and adds the new `pr-preamble-message` input, so opam-repository PRs opened by the release flow carry a note about who to contact:

> Released automatically by dune-release-action. Contact @davesnx or @andreypopp

The preamble is prepended to the PR description, before the changelog content. Other notable changes in v0.4.0: the `publish-message` input is fixed (it was previously passed as an unrecognized `--msg` flag) and the action runtime runs on Node.js 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
